### PR TITLE
Render Obsidian Multi-Column Markdown in the learning wiki

### DIFF
--- a/src/scripts/learning-wiki.ts
+++ b/src/scripts/learning-wiki.ts
@@ -2,9 +2,13 @@ import * as d3 from 'd3';
 import { marked } from 'marked';
 import katex from 'katex';
 import { calloutExtension } from './wiki-callouts';
+import {
+  multiColumnExtension,
+  padMultiColumnMarkers,
+} from './wiki-multi-column';
 
 marked.setOptions({ breaks: true });
-marked.use({ extensions: [calloutExtension] });
+marked.use({ extensions: [calloutExtension, multiColumnExtension] });
 
 function slugifyHeading(text: string): string {
   return text
@@ -333,7 +337,11 @@ function openNote(id: string) {
 
   document.getElementById('note-title')!.textContent = note.id;
 
-  // 3. Extract math BEFORE marked runs, so `&` and `\\` inside $$...$$ survive
+  // 3. Pad multi-column markers with blank lines so marked treats them as
+  //    standalone blocks (otherwise paragraph continuation absorbs them).
+  processed = padMultiColumnMarkers(processed);
+
+  // 4. Extract math BEFORE marked runs, so `&` and `\\` inside $$...$$ survive
   //    HTML-escaping and CommonMark backslash-escape handling.
   const { text: markdownWithMathSlots, blocks: mathBlocks } =
     extractMath(processed);

--- a/src/scripts/wiki-multi-column.ts
+++ b/src/scripts/wiki-multi-column.ts
@@ -1,0 +1,143 @@
+import type { TokenizerAndRendererExtension, Tokens } from 'marked';
+
+interface MultiColumnToken extends Tokens.Generic {
+  type: 'multiColumn';
+  raw: string;
+  gridTemplate: string;
+  columnTokens: Tokens.Generic[][];
+}
+
+const START_RE = /^--- start-multi-column[ \t]*\n/;
+const END_RE = /\n--- end-multi-column\b[^\n]*(?:\n|$)/;
+const COLUMN_BREAK_RE = /\n--- column-break[ \t-]*\n/g;
+const SETTINGS_CLOSER_RE = /^---[ \t]*$/;
+const SETTING_LINE_RE = /^([A-Za-z][A-Za-z0-9 _-]*?)\s*:\s*(.*)$/;
+const NEXT_MARKER_RE = /^--- (?:column-break|end-multi-column)\b/;
+
+const MARKER_LINE_RE =
+  /^(--- (?:start-multi-column|column-break|end-multi-column)\b[^\n]*)$/gm;
+
+// Marked's paragraph rule lazily absorbs unindented continuation lines, and the
+// `---` settings closer would otherwise be parsed as a setext heading underline.
+// Surrounding marker lines with blank lines forces them to start their own
+// blocks so the multi-column tokenizer can claim the region.
+export function padMultiColumnMarkers(src: string): string {
+  return src.replace(MARKER_LINE_RE, '\n$1\n');
+}
+
+function parseSettings(lines: string[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const line of lines) {
+    const m = line.match(SETTING_LINE_RE);
+    if (!m) continue;
+    const key = m[1].toLowerCase().replace(/\s+/g, ' ').trim();
+    out[key] = m[2].trim();
+  }
+  return out;
+}
+
+function parseSizes(raw: string | undefined): number[] | null {
+  if (!raw) return null;
+  const inner = raw.replace(/^\[/, '').replace(/\]$/, '');
+  const parts = inner
+    .split(/[\s,]+/)
+    .map((p) => parseFloat(p))
+    .filter((n) => Number.isFinite(n) && n > 0);
+  return parts.length ? parts : null;
+}
+
+function splitSettingsAndBody(inner: string): {
+  settings: Record<string, string>;
+  body: string;
+} {
+  const stripped = inner.replace(/^\n+/, '');
+  const lines = stripped.split('\n');
+  if (lines.length === 0 || !SETTING_LINE_RE.test(lines[0])) {
+    return { settings: {}, body: stripped };
+  }
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (SETTINGS_CLOSER_RE.test(line)) {
+      const candidate = lines.slice(0, i);
+      const allSettings = candidate
+        .filter((l) => l.trim())
+        .every((l) => SETTING_LINE_RE.test(l));
+      if (!allSettings) break;
+      const body = lines
+        .slice(i + 1)
+        .join('\n')
+        .replace(/^\n+/, '');
+      return { settings: parseSettings(candidate), body };
+    }
+    if (NEXT_MARKER_RE.test(line)) break;
+  }
+  return { settings: {}, body: inner };
+}
+
+function gridTemplate(columnCount: number, sizes: number[] | null): string {
+  if (sizes && sizes.length === columnCount) {
+    return sizes.map((s) => `${s}fr`).join(' ');
+  }
+  return `repeat(${columnCount}, 1fr)`;
+}
+
+export const multiColumnExtension: TokenizerAndRendererExtension = {
+  name: 'multiColumn',
+  level: 'block',
+  start(src: string) {
+    const idx = src.search(/^--- start-multi-column/m);
+    return idx === -1 ? undefined : idx;
+  },
+  tokenizer(src: string): MultiColumnToken | undefined {
+    const startMatch = src.match(START_RE);
+    if (!startMatch || startMatch.index !== 0) return undefined;
+
+    const afterStart = src.slice(startMatch[0].length);
+    const endMatch = afterStart.match(END_RE);
+    if (!endMatch || endMatch.index === undefined) return undefined;
+
+    const innerRaw = afterStart.slice(0, endMatch.index);
+    const raw = src.slice(
+      0,
+      startMatch[0].length + endMatch.index + endMatch[0].length,
+    );
+
+    const { settings, body } = splitSettingsAndBody(innerRaw);
+
+    const columns = body
+      .split(COLUMN_BREAK_RE)
+      .map((c) => c.replace(/^\n+|\n+$/g, ''));
+
+    let columnCount = parseInt(settings['number of columns'] || '', 10);
+    if (!Number.isFinite(columnCount) || columnCount < 1) {
+      columnCount = columns.length;
+    }
+    while (columns.length < columnCount) columns.push('');
+
+    const sizes = parseSizes(settings['column size']);
+    const template = gridTemplate(columnCount, sizes);
+
+    const columnTokens: Tokens.Generic[][] = columns.map((col) => {
+      const tokens: Tokens.Generic[] = [];
+      this.lexer.blockTokens(col, tokens);
+      return tokens;
+    });
+
+    return {
+      type: 'multiColumn',
+      raw,
+      gridTemplate: template,
+      columnTokens,
+    };
+  },
+  renderer(token) {
+    const t = token as MultiColumnToken;
+    const inner = t.columnTokens
+      .map(
+        (toks) =>
+          `<div class="multi-column-col">${this.parser.parse(toks)}</div>`,
+      )
+      .join('');
+    return `<div class="multi-column" style="grid-template-columns: ${t.gridTemplate};">${inner}</div>`;
+  },
+};

--- a/src/styles/learning-wiki.css
+++ b/src/styles/learning-wiki.css
@@ -574,3 +574,22 @@
   --callout-accent: #0ea5e9;
   --callout-bg: #f0f9ff;
 }
+
+/* ── Multi-Column Markdown (Obsidian plugin) ── */
+.md-body .multi-column {
+  display: grid;
+  gap: 1.25rem;
+  margin: 1rem 0;
+  align-items: start;
+}
+.md-body .multi-column-col > *:first-child {
+  margin-top: 0;
+}
+.md-body .multi-column-col > *:last-child {
+  margin-bottom: 0;
+}
+@media (max-width: 768px) {
+  .md-body .multi-column {
+    grid-template-columns: 1fr !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a `marked` block extension (`src/scripts/wiki-multi-column.ts`) that recognizes the [Multi-Column Markdown](https://github.com/ckRobinson/multi-column-markdown) Obsidian plugin's `--- start-multi-column` / `--- column-break ---` / `--- end-multi-column` fence syntax, parses its settings block (`number of columns`, `column size: [...]`), and renders each column as a CSS-grid cell.
- Wires the extension into `src/scripts/learning-wiki.ts` alongside the existing callout extension, plus a small preprocessing pass that pads marker lines with blank lines so the paragraph rule and setext-heading rule don't swallow them.
- Adds `.multi-column` grid styles in `src/styles/learning-wiki.css`, with a `<768px` media query that stacks columns vertically on mobile.

Without this, notes like `obs_notes/public/Computer Vision/Feature Detection.md` rendered the markers and settings as raw text on the live site instead of as side-by-side columns.

## Test plan
- [ ] `npm run build` completes cleanly
- [ ] `npm run dev`, open `/learning-wiki`, click **Feature Detection**, confirm the "Edge detection" section shows derivatives on the left (~55%) and the pixel-coordinate table on the right (~45%) with no leaked `--- start-multi-column` / `--- column-break ---` text
- [ ] KaTeX `$$dx = …$$` math still renders inside the left column
- [ ] Resize below 768px, confirm columns stack vertically
- [ ] Open another note without multi-column syntax, confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)