### PR TITLE
Site polish: animations, project filter, footer, mobile

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,10 +2,39 @@
 import { author } from '../data/author';
 
 const year = new Date().getFullYear();
+
+// Icons mirror the sidebar set so the footer's social row reads consistently.
+const icons: Record<string, string> = {
+  github: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>`,
+  linkedin: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>`,
+  file: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6zm-1 1.5L18.5 9H13V3.5zM6 20V4h5v7h7v9H6z"/></svg>`,
+  email: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4-8 5-8-5V6l8 5 8-5v2z"/></svg>`,
+};
 ---
 
 <footer class="site-footer">
   <div class="site-footer__inner">
+    <nav class="site-footer__social" aria-label="Social links">
+      {
+        author.links.map((link) => (
+          <a
+            href={link.url}
+            class="site-footer__social-link"
+            target={link.url.startsWith('http') ? '_blank' : undefined}
+            rel={
+              link.url.startsWith('http') ? 'noopener noreferrer' : undefined
+            }
+            aria-label={link.label}
+          >
+            <span
+              class="site-footer__social-icon"
+              set:html={icons[link.icon] ?? icons.file}
+            />
+            <span>{link.label}</span>
+          </a>
+        ))
+      }
+    </nav>
     <p class="site-footer__colophon">
       &copy; {year}
       {author.name}. Built with
@@ -39,6 +68,33 @@ const year = new Date().getFullYear();
     display: flex;
     flex-direction: column;
     gap: 1rem;
+  }
+
+  /* Social row — sits above the colophon (two-row footer pattern). */
+  .site-footer__social {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.25rem;
+  }
+
+  .site-footer__social-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--fg-muted);
+    text-decoration: none;
+  }
+
+  .site-footer__social-link:hover {
+    color: var(--fg);
+  }
+
+  .site-footer__social-icon {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
   }
 
   .site-footer__colophon {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,6 +35,9 @@ import SidebarLayout from '../layouts/SidebarLayout.astro';
     letter-spacing: -0.02em;
     color: var(--fg);
     margin: 0;
+    /* Intro: the lead text slides in from the right. */
+    animation: home-slide-right 0.8s cubic-bezier(0.2, 0.7, 0.3, 1) both;
+    animation-delay: 0.1s;
   }
 
   .home-hero__body {
@@ -42,6 +45,26 @@ import SidebarLayout from '../layouts/SidebarLayout.astro';
     line-height: 1.6;
     color: var(--fg);
     margin: 1.5rem 0 0;
+    animation: home-slide-right 0.8s cubic-bezier(0.2, 0.7, 0.3, 1) both;
+    animation-delay: 0.28s;
+  }
+
+  @keyframes home-slide-right {
+    from {
+      opacity: 0;
+      transform: translateX(32px);
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .home-hero__lead,
+    .home-hero__body {
+      animation: none;
+    }
   }
 
   .home-hero__body strong {

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -108,37 +108,58 @@ const allTags = getAllTags();
       });
     });
 
-    // Tag filtering
-    const filterButtons = document.querySelectorAll('.tag-filter');
+    // Tag filtering — toggleable + multi-select.
+    // Click a tag to add it, click again to remove it. With several tags
+    // selected, a project shows if it matches ANY of them. "All" clears
+    // the selection (and is active whenever nothing is selected).
+    const filterButtons = document.querySelectorAll<HTMLElement>('.tag-filter');
+    const allButton = document.querySelector<HTMLElement>(
+      '.tag-filter[data-tag="all"]',
+    );
     const projectItems = document.querySelectorAll('.project-item');
     const sections = document.querySelectorAll('.project-section');
+    const selectedTags = new Set<string>();
+
+    const applyFilter = () => {
+      // Reflect selection state on the buttons.
+      filterButtons.forEach((b) => {
+        const tag = b.getAttribute('data-tag')!;
+        b.classList.toggle('active', selectedTags.has(tag));
+      });
+      allButton?.classList.toggle('active', selectedTags.size === 0);
+
+      projectItems.forEach((item) => {
+        const tags: string[] = JSON.parse(
+          item.getAttribute('data-tags') || '[]',
+        );
+        const visible =
+          selectedTags.size === 0 || tags.some((t) => selectedTags.has(t));
+        (item as HTMLElement).style.display = visible ? '' : 'none';
+      });
+
+      sections.forEach((section) => {
+        const visibleCards = section.querySelectorAll(
+          '.project-item:not([style*="display: none"])',
+        );
+        (section as HTMLElement).style.display =
+          visibleCards.length === 0 ? 'none' : '';
+      });
+    };
 
     filterButtons.forEach((btn) => {
       btn.addEventListener('click', () => {
-        filterButtons.forEach((b) => b.classList.remove('active'));
-        btn.classList.add('active');
-
-        const selectedTag = btn.getAttribute('data-tag');
-
-        projectItems.forEach((item) => {
-          const tags: string[] = JSON.parse(
-            item.getAttribute('data-tags') || '[]',
-          );
-          if (selectedTag === 'all' || tags.includes(selectedTag!)) {
-            (item as HTMLElement).style.display = '';
-          } else {
-            (item as HTMLElement).style.display = 'none';
-          }
-        });
-
-        sections.forEach((section) => {
-          const visibleCards = section.querySelectorAll(
-            '.project-item:not([style*="display: none"])',
-          );
-          (section as HTMLElement).style.display =
-            visibleCards.length === 0 ? 'none' : '';
-        });
+        const tag = btn.getAttribute('data-tag')!;
+        if (tag === 'all') {
+          selectedTags.clear();
+        } else if (selectedTags.has(tag)) {
+          selectedTags.delete(tag); // toggle off (deselect)
+        } else {
+          selectedTags.add(tag); // toggle on
+        }
+        applyFilter();
       });
     });
+
+    applyFilter();
   });
 </script>

--- a/src/styles/projects.css
+++ b/src/styles/projects.css
@@ -171,3 +171,20 @@
   background: var(--bg-surface);
   color: var(--fg-muted);
 }
+
+/* Phones: tighten padding and force a single, full-width column so the
+   18em card minimum never overflows a narrow screen (issue #41). */
+@media (max-width: 600px) {
+  .projects-page {
+    padding: 1.5rem 1rem;
+  }
+
+  .projects-grid {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+
+  .project-item {
+    padding: 20px;
+  }
+}

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -14,6 +14,8 @@
   border-radius: 50%;
   object-fit: cover;
   margin-bottom: 1rem;
+  /* Intro: the photo slides in from the left. */
+  animation: sidebar-slide-left 0.7s cubic-bezier(0.2, 0.7, 0.3, 1) both;
 }
 
 .sidebar-location {
@@ -24,6 +26,8 @@
   font-size: 0.8rem;
   color: var(--fg-muted);
   margin-bottom: 1.1rem;
+  animation: sidebar-slide-left 0.7s cubic-bezier(0.2, 0.7, 0.3, 1) both;
+  animation-delay: 0.12s;
 }
 
 .sidebar-links {
@@ -44,6 +48,44 @@
   font-weight: 500;
   color: var(--fg-muted);
   padding: 0.2rem 0;
+  /* Intro: each social link slides in from the left, one after another. */
+  animation: sidebar-slide-left 0.6s cubic-bezier(0.2, 0.7, 0.3, 1) both;
+}
+
+/* Stagger the social links so they arrive one by one after the photo. */
+.sidebar-link:nth-child(1) {
+  animation-delay: 0.45s;
+}
+.sidebar-link:nth-child(2) {
+  animation-delay: 0.58s;
+}
+.sidebar-link:nth-child(3) {
+  animation-delay: 0.71s;
+}
+.sidebar-link:nth-child(4) {
+  animation-delay: 0.84s;
+}
+.sidebar-link:nth-child(5) {
+  animation-delay: 0.97s;
+}
+
+@keyframes sidebar-slide-left {
+  from {
+    opacity: 0;
+    transform: translateX(-26px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sidebar-avatar,
+  .sidebar-location,
+  .sidebar-link {
+    animation: none;
+  }
 }
 
 .sidebar-link:hover {

--- a/src/styles/travel.css
+++ b/src/styles/travel.css
@@ -63,8 +63,8 @@ body {
   height: 100%;
   display: block;
   overflow: hidden;
-  /* First-render: the globe settles in. */
-  animation: mapIn 0.9s cubic-bezier(0.2, 0.7, 0.3, 1) both;
+  /* First-render: the globe settles in (slow, unhurried). */
+  animation: mapIn 1.7s cubic-bezier(0.2, 0.7, 0.3, 1) both;
 }
 @keyframes mapIn {
   from {
@@ -200,8 +200,8 @@ body {
   vector-effect: non-scaling-stroke;
   opacity: 0.45;
   /* First-render: the route fades in after the pins land. */
-  animation: routeIn 0.9s ease both;
-  animation-delay: 0.55s;
+  animation: routeIn 1.4s ease both;
+  animation-delay: 1.3s;
 }
 @keyframes routeIn {
   from {
@@ -222,8 +222,9 @@ body {
 /* Intro: pins pop out of the globe on load, staggered. */
 .pin-pop {
   transform-origin: 0 0; /* the teardrop tip = the shop location */
-  animation: pinIn 0.55s cubic-bezier(0.2, 0.75, 0.3, 1.15) both;
-  animation-delay: calc(var(--i, 0) * 0.06s);
+  animation: pinIn 0.85s cubic-bezier(0.2, 0.75, 0.3, 1.15) both;
+  /* Pins pop in gently, one after another, after the globe settles. */
+  animation-delay: calc(0.8s + var(--i, 0) * 0.16s);
 }
 @keyframes pinIn {
   from {
@@ -483,5 +484,36 @@ body {
   }
   .polaroid {
     transition: none;
+  }
+}
+
+/* ---- Touch devices: bigger, easier-to-tap pins & targets (issue #41) ----
+   The map is rendered small on phones, so enlarge the pins and their hit
+   area, and stop relying on hover (which doesn't exist on touch). */
+@media (pointer: coarse) {
+  .pin {
+    --pin-base: 1.45;
+  }
+  .pin-hit {
+    r: 24px; /* generous, finger-sized tap target */
+  }
+  /* Show each shop's name flag by default since there is no hover. */
+  .pin-flag-text {
+    opacity: 1;
+  }
+}
+
+/* ---- Small screens: give the map more room ---- */
+@media (max-width: 600px) {
+  .travel-line {
+    padding: 0.7rem 1rem 0.3rem;
+  }
+  .map-back {
+    top: 0.6rem;
+    left: 0.6rem;
+    font-size: 1.1rem;
+  }
+  .collage {
+    padding: 1.25rem 1rem 1.5rem;
   }
 }


### PR DESCRIPTION
Resolves a batch of open issues around polish, interactivity, and mobile.

## Changes
- **#40 — Slower coffee-map intro.** Globe settles more slowly, pins pop in gently one-by-one after it lands, route fades in last.
- **#29 — Homepage intro animations.** Avatar + location + social links slide in from the left (links staggered); hero text slides in from the right. Gated behind `prefers-reduced-motion`.
- **#14 — Project filter select/deselect.** Tag filter is now toggleable (click again to deselect) and multi-select; a project shows if it matches *any* selected tag. "All" clears the selection.
- **#26 — Intro refresh + footer.** Homepage intro animation refresh, and the footer now follows the two-row pattern (social row + colophon) from the design system. Chat feature intentionally deferred (not viable on static GitHub Pages without an external service).
- **#41 — Phone compatibility.** Single-column projects grid on small screens, larger touch targets + always-visible labels on the coffee map for touch devices, tighter small-screen spacing. Other pages already had working breakpoints.

## Verification
- `npm run build` and `astro check` pass (0 errors).
- Verified in-browser at desktop and 390px width: multi-select/deselect filter, homepage stacking, coffee map + collage on mobile.

## Not included
- **#13 (problem/solution per project)** was implemented then removed at the author's request — closing it as won't-do.

Closes #40
Closes #29
Closes #14
Closes #26
Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)